### PR TITLE
Issue #18 Bug fix to decode 200 response content from bytes to str

### DIFF
--- a/fhirpy/lib.py
+++ b/fhirpy/lib.py
@@ -108,7 +108,7 @@ class FHIRClient:
             headers={'Authorization': self.authorization})
 
         if 200 <= r.status_code < 300:
-            return json.loads(r.content) if r.content else None
+            return json.loads(r.content.decode()) if r.content else None
 
         if r.status_code == 404:
             raise FHIRResourceNotFound(r.content.decode())


### PR DESCRIPTION
While our response object is utf-8, our r.content doesn't contain an encoding attribute, as it is a bytes object, causing json.loads to fail as it's expecting a string object.

So we call decode on our r.content object to convert it to a string object that json.loads is expecting.

We could probably specify 'utf-8' explicitly here, but I do not.