### PR TITLE
Issue #20 Fix to allow extra headers to be defined as a JSON attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Import library:
 
 To create FHIR instance use:
 
-`FHIRClient(url, authorization='', version='3.0.1', without_cache=False)`
+`FHIRClient(url, authorization='', version='3.0.1', without_cache=False, extra_headers={'Client_Id': 'AoNN12x'})`
 
 Returns an instance of the connection to the server which provides:
 * .reference(resource_type, id, reference, **kwargs) - returns `FHIRReference` to the resource

--- a/fhirpy/lib.py
+++ b/fhirpy/lib.py
@@ -30,14 +30,16 @@ class FHIRClient:
     url = None
     authorization = None
     without_cache = False
+    extra_headers = None
 
     def __init__(self, url, authorization=None, without_cache=False,
-                 fhir_version='3.0.1'):
+                 fhir_version='3.0.1', extra_headers=None):
         self.url = url
         self.authorization = authorization
         self.resources_cache = defaultdict(dict)
         self.without_cache = without_cache
         self.schema = load_schema(fhir_version)
+        self.extra_headers = extra_headers
 
     def __str__(self):  # pragma: no cover
         return '<FHIRClient {0}>'.format(self.url)
@@ -101,11 +103,16 @@ class FHIRClient:
         params.update({'_format': 'json'})
         url = '{0}/{1}?{2}'.format(
             self.url, path, encode_params(params))
+        headers={'Authorization': self.authorization}
+
+        if self.extra_headers is not None:
+            headers = {**headers, **self.extra_headers}
+
         r = requests.request(
             method,
             url,
             json=data,
-            headers={'Authorization': self.authorization})
+            headers=headers)
 
         if 200 <= r.status_code < 300:
             return json.loads(r.content) if r.content else None


### PR DESCRIPTION
For some EHRs we need to pass in client IDs and/or other authorization data. At this time we cannot, or we have to hijack the authorization attribute, which is not intuitive and awkward.

With this we add in an extra_headers attribute with is optional. When included we unpack the JSON object and add it to the headers object.

Add in the extra_headers information into the README as well.