### PR TITLE
Use Resource Type for Next Url

### DIFF
--- a/fhirpy/base/lib.py
+++ b/fhirpy/base/lib.py
@@ -178,8 +178,9 @@ class SyncSearchSet(AbstractSearchSet, ABC):
         next_link = None
         while True:
             if next_link:
-                bundle_data = self.client._fetch_resource(*parse_pagination_url(
-                    next_link))
+                bundle_data = self.client._fetch_resource(
+                    self.resource_type, parse_pagination_url(next_link)
+                )
             else:
                 bundle_data = self.client._fetch_resource(
                     self.resource_type, self.params
@@ -256,7 +257,8 @@ class AsyncSearchSet(AbstractSearchSet, ABC):
         while True:
             if next_link:
                 bundle_data = await self.client._fetch_resource(
-                    self.resource_type, parse_pagination_url(next_link))
+                    self.resource_type, parse_pagination_url(next_link)
+                )
             else:
                 bundle_data = await self.client._fetch_resource(
                     self.resource_type, self.params

--- a/fhirpy/base/lib.py
+++ b/fhirpy/base/lib.py
@@ -77,12 +77,11 @@ class AbstractClient(ABC):
         params = params or {}
         params['_format'] = 'json'
 
-        seq_matcher = SequenceMatcher(None, path, self.url)
-        match = seq_matcher.find_longest_match(0, len(path), 0, len(self.url))
-
-        if match.size > 0:
-            match_word = path[match.a:match.size]
-            path = path.replace(match_word, '')
+        split_path = path.split('/')
+        if len(split_path) > 1:
+            split_url = self.url.split('/')
+            unique_parts = [item for item in split_path if item not in split_url]
+            path = '/'.join(unique_parts)
         
         return f'{self.url}/{path.lstrip("/")}?{encode_params(params)}'
 

--- a/fhirpy/base/lib.py
+++ b/fhirpy/base/lib.py
@@ -255,7 +255,8 @@ class AsyncSearchSet(AbstractSearchSet, ABC):
         next_link = None
         while True:
             if next_link:
-                bundle_data = await self.client._fetch_resource(*parse_pagination_url(next_link))
+                bundle_data = await self.client._fetch_resource(
+                    self.resource_type, parse_pagination_url(next_link))
             else:
                 bundle_data = await self.client._fetch_resource(
                     self.resource_type, self.params

--- a/fhirpy/base/utils.py
+++ b/fhirpy/base/utils.py
@@ -77,8 +77,9 @@ def parse_pagination_url(url):
     """
     parsed = urlparse(url)
     params = parse_qs(parsed.query)
+    path = parsed.path
 
-    return params
+    return path, params
 
 
 def convert_values(data, fn):

--- a/fhirpy/base/utils.py
+++ b/fhirpy/base/utils.py
@@ -77,9 +77,8 @@ def parse_pagination_url(url):
     """
     parsed = urlparse(url)
     params = parse_qs(parsed.query)
-    path = parsed.path
 
-    return path, params
+    return params
 
 
 def convert_values(data, fn):


### PR DESCRIPTION
Using the path from parse_pagination_url was causing issues in the next page url.

For example my base url is:
`https://fhir.com/fhir/api/fhir-R4/Encounter?=1234`

Using the path, the next url would look like:
`https://fhir.com/fhir/api/fhir-R4/fhir/api/fhir-R4/Encounter?_query=1234`

The above will fail since the path is duplicated in the url. I change this by just using the resource type like for the first page.

