### PR TITLE
Return attribute error when using attribute

### DIFF
--- a/fhirpy/base/resource.py
+++ b/fhirpy/base/resource.py
@@ -23,7 +23,7 @@ class AbstractResource(dict):
         try:
             return super(AbstractResource, self).__getitem__(key)
         except KeyError as e:
-            raise AttributeError(e)
+            raise AttributeError from e
 
     def __getattr__(self, key):
         return self[key]

--- a/fhirpy/base/resource.py
+++ b/fhirpy/base/resource.py
@@ -20,7 +20,10 @@ class AbstractResource(dict):
         super(AbstractResource, self).__setitem__(key, value)
 
     def __getitem__(self, key):
-        return super(AbstractResource, self).__getitem__(key)
+        try:
+            return super(AbstractResource, self).__getitem__(key)
+        except KeyError as e:
+            raise AttributeError(e)
 
     def __getattr__(self, key):
         return self[key]


### PR DESCRIPTION
will return an attribute error that fixes python builtin methods like gettatribute.
#66