### PR TITLE
Changed Accept header to application/fhir+json

### DIFF
--- a/fhirpy/base/lib.py
+++ b/fhirpy/base/lib.py
@@ -78,7 +78,7 @@ class AbstractClient(ABC):
         pass
 
     def _build_request_headers(self):
-        headers = {"Accept": "application/json"}
+        headers = {"Accept": "application/fhir+json"}
 
         if self.authorization:
             headers["Authorization"] = self.authorization


### PR DESCRIPTION
Per the [standard](https://www.hl7.org/fhir/json.html) required that the requested MIME type should be `application/fhir+json`.
This is especially critical with [Binary](https://www.hl7.org/fhir/binary.html) resources, as they are returned not as JSON objects but as raw data, unless requested with the correct `Accept` header