### PR TITLE
Fix get resource by id (use rt/id, not search(_id=))

### DIFF
--- a/fhirpy/base/lib.py
+++ b/fhirpy/base/lib.py
@@ -441,7 +441,8 @@ class SyncReference(BaseReference, ABC):
         """
         if not self.is_local:
             raise ResourceNotFound("Can not resolve not local resource")
-        return self.client.resources(self.resource_type).search(_id=self.id).get()
+        resource_data = self.client._do_request("get", "{0}/{1}".format(self.resource_type, self.id))
+        return self._perform_resource(resource_data)
 
     def execute(self, operation, method="post", **kwargs):
         if not self.is_local:
@@ -461,7 +462,8 @@ class AsyncReference(BaseReference, ABC):
         """
         if not self.is_local:
             raise ResourceNotFound("Can not resolve not local resource")
-        return await self.client.resources(self.resource_type).search(_id=self.id).get()
+        resource_data = await self.client._do_request("get", "{0}/{1}".format(self.resource_type, self.id))
+        return self._perform_resource(resource_data)
 
     async def execute(self, operation, method="post", **kwargs):
         if not self.is_local:

--- a/fhirpy/base/lib.py
+++ b/fhirpy/base/lib.py
@@ -200,7 +200,7 @@ class SyncSearchSet(AbstractSearchSet, ABC):
 
         if data_resource_type == "Bundle":
             for item in data["entry"]:
-                item.resource = self._perform_resource(item.resource)
+                item.resource = self._dict_to_resource(item.resource)
 
         return data
 
@@ -224,7 +224,7 @@ class SyncSearchSet(AbstractSearchSet, ABC):
         elif len(res_data) > 1:
             raise MultipleResourcesFound("More than one resource found")
         resource = res_data[0]
-        return self._perform_resource(resource)
+        return self._dict_to_resource(resource)
 
     def count(self):
         new_params = copy.deepcopy(self.params)
@@ -273,7 +273,7 @@ class AsyncSearchSet(AbstractSearchSet, ABC):
 
         if data_resource_type == "Bundle":
             for item in data["entry"]:
-                item.resource = self._perform_resource(item.resource)
+                item.resource = self._dict_to_resource(item.resource)
 
         return data
 
@@ -297,7 +297,7 @@ class AsyncSearchSet(AbstractSearchSet, ABC):
         elif len(res_data) > 1:
             raise MultipleResourcesFound("More than one resource found")
         resource = res_data[0]
-        return self._perform_resource(resource)
+        return self._dict_to_resource(resource)
 
     async def count(self):
         new_params = copy.deepcopy(self.params)
@@ -442,7 +442,7 @@ class SyncReference(BaseReference, ABC):
         if not self.is_local:
             raise ResourceNotFound("Can not resolve not local resource")
         resource_data = self.client._do_request("get", "{0}/{1}".format(self.resource_type, self.id))
-        return self._perform_resource(resource_data)
+        return self._dict_to_resource(resource_data)
 
     def execute(self, operation, method="post", **kwargs):
         if not self.is_local:
@@ -463,7 +463,7 @@ class AsyncReference(BaseReference, ABC):
         if not self.is_local:
             raise ResourceNotFound("Can not resolve not local resource")
         resource_data = await self.client._do_request("get", "{0}/{1}".format(self.resource_type, self.id))
-        return self._perform_resource(resource_data)
+        return self._dict_to_resource(resource_data)
 
     async def execute(self, operation, method="post", **kwargs):
         if not self.is_local:

--- a/fhirpy/base/resource.py
+++ b/fhirpy/base/resource.py
@@ -190,6 +190,11 @@ class BaseReference(AbstractResource):
         """
         return self.client.reference(reference=self.reference, **kwargs)
 
+    def _perform_resource(self, data):
+        resource_type = data.get("resourceType", None)
+        resource = self.client.resource(resource_type, **data)
+        return resource
+
     @property  # pragma: no cover
     @abstractmethod
     def reference(self):

--- a/fhirpy/base/resource.py
+++ b/fhirpy/base/resource.py
@@ -190,10 +190,8 @@ class BaseReference(AbstractResource):
         """
         return self.client.reference(reference=self.reference, **kwargs)
 
-    def _perform_resource(self, data):
-        resource_type = data.get("resourceType", None)
-        resource = self.client.resource(resource_type, **data)
-        return resource
+    def _dict_to_resource(self, data):
+        return self.client.resource(data['resourceType'], **data)
 
     @property  # pragma: no cover
     @abstractmethod

--- a/fhirpy/base/searchset.py
+++ b/fhirpy/base/searchset.py
@@ -179,10 +179,8 @@ class AbstractSearchSet(ABC):
         self.resource_type = resource_type
         self.params = defaultdict(list, params or {})
 
-    def _perform_resource(self, data):
-        resource_type = data.get("resourceType", None)
-        resource = self.client.resource(resource_type, **data)
-        return resource
+    def _dict_to_resource(self, data):
+        return self.client.resource(data['resourceType'], **data)
 
     @abstractmethod  # pragma: no cover
     def fetch(self):
@@ -331,7 +329,7 @@ class AbstractSearchSet(ABC):
 
         resources = []
         for data in resources_data:
-            resource = self._perform_resource(data)
+            resource = self._dict_to_resource(data)
             if resource.resource_type == self.resource_type:
                 resources.append(resource)
         return resources


### PR DESCRIPTION
Fix a discrepancy between documentation (https://github.com/beda-software/fhir-py#get-resource-by-id) and actual http request that is executed in reference.to_resource()