### PR TITLE
Remove trailing '/' from base url when building resource location path

### DIFF
--- a/fhirpy/base/client.py
+++ b/fhirpy/base/client.py
@@ -145,7 +145,7 @@ class AbstractClient(ABC):
                 " (possible security issue)"
             )
         path = path.lstrip("/")
-        base_url_path = URL(self.url).path.lstrip("/") + "/"
+        base_url_path = URL(self.url.rstrip("/")).path.lstrip("/") + "/"
         path = remove_prefix(path, base_url_path)
         params = params or {}
 


### PR DESCRIPTION
Resolve issue with parsing Bundle relative links (next, prev) when FHIR API URL ends with a trailing `/`.

For example, previously `http://base_url/fhir/` would be parsed into `base_url` and `/fhir/` path, the path then would be transformed into `fhir//` and the `fhir//` prefix would not match relative FHIR links (like `fhir/CarePlan`) resulting in a broken FHIR API query `http://base_url/fhir/fhir/CarePlan`.