### PR TITLE
fix: preserve empty list/dict values in serialize() when fields specified (#146)

### DIFF
--- a/fhirpy/base/lib_async.py
+++ b/fhirpy/base/lib_async.py
@@ -122,7 +122,7 @@ class AsyncClient(AbstractClient, ABC):
         # _as_dict is a private api used internally
         _as_dict: bool = False,
     ) -> Union[TResource, dict]:
-        data = serialize(self.dump_resource(resource), drop_nulls_from_dicts=fields is None)
+        data = serialize(self.dump_resource(resource), drop_nulls_from_dicts=fields is None, fields=fields)
         if fields:
             if not resource.id:
                 raise TypeError("Resource `id` is required for update operation")

--- a/fhirpy/base/lib_sync.py
+++ b/fhirpy/base/lib_sync.py
@@ -120,7 +120,7 @@ class SyncClient(AbstractClient, ABC):
         # _as_dict is a private api used internally
         _as_dict: bool = False,
     ) -> Union[TResource, dict]:
-        data = serialize(self.dump_resource(resource), drop_nulls_from_dicts=fields is None)
+        data = serialize(self.dump_resource(resource), drop_nulls_from_dicts=fields is None, fields=fields)
         if fields:
             if not resource.id:
                 raise TypeError("Resource `id` is required for update operation")

--- a/fhirpy/base/resource.py
+++ b/fhirpy/base/resource.py
@@ -256,7 +256,7 @@ class BaseReference(Generic[TClient, TResource, TReference], AbstractResource[TC
         pass
 
 
-def serialize(resource: Any, drop_nulls_from_dicts=True) -> dict:
+def serialize(resource: Any, drop_nulls_from_dicts=True, fields=None) -> dict:
     def convert_fn(item):
         if isinstance(item, BaseResource):
             return serialize(item.to_reference()), True
@@ -271,4 +271,15 @@ def serialize(resource: Any, drop_nulls_from_dicts=True) -> dict:
     if drop_nulls_from_dicts:
         converted_values = remove_nulls_from_dicts(converted_values)
 
-    return clean_empty_values(converted_values)
+    cleaned = clean_empty_values(converted_values)
+
+    # When fields are specified (patch/update_fields), preserve empty values
+    # for the explicitly requested fields. clean_empty_values strips empty
+    # lists and dicts, but users may intentionally set fields to [] or {}
+    # to clear them via a partial update.
+    if fields:
+        for key in fields:
+            if key in converted_values and key not in cleaned:
+                cleaned[key] = converted_values[key]
+
+    return cleaned

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -84,3 +84,57 @@ def test_clean_empty_values():
     assert clean_empty_values({"item": [None, {"item": None}, {}]}) == {
         "item": [None, {"item": None}, None]
     }
+
+
+def test_serialize_preserves_empty_list_for_specified_fields():
+    """serialize() must preserve empty lists/dicts when the key is in `fields`.
+
+    Regression test for https://github.com/beda-software/fhir-py/issues/146:
+    save(update_fields=["generalPractitioner"]) fails with KeyError when the
+    field value is [] because clean_empty_values strips it.
+    """
+    from fhirpy.base.resource import serialize
+
+    # Simulate a resource dict with an empty list field
+    resource_data = {
+        "resourceType": "Patient",
+        "id": "test-123",
+        "generalPractitioner": [],
+        "name": [{"family": "Smith"}],
+    }
+
+    # Without fields: empty list is stripped (existing behavior)
+    result_no_fields = serialize(resource_data)
+    assert "generalPractitioner" not in result_no_fields
+    assert result_no_fields["name"] == [{"family": "Smith"}]
+
+    # With fields including the empty list: it must be preserved
+    result_with_fields = serialize(resource_data, fields=["generalPractitioner"])
+    assert "generalPractitioner" in result_with_fields
+    assert result_with_fields["generalPractitioner"] == []
+
+    # With fields NOT including the empty list: it should still be stripped
+    result_other_field = serialize(resource_data, fields=["name"])
+    assert "generalPractitioner" not in result_other_field
+    assert result_other_field["name"] == [{"family": "Smith"}]
+
+
+def test_serialize_preserves_empty_dict_for_specified_fields():
+    """serialize() must also preserve empty dicts when in `fields`."""
+    from fhirpy.base.resource import serialize
+
+    resource_data = {
+        "resourceType": "Patient",
+        "id": "test-456",
+        "contact": {},
+        "active": True,
+    }
+
+    # Empty dict stripped without fields
+    result_no_fields = serialize(resource_data)
+    assert "contact" not in result_no_fields
+
+    # Empty dict preserved when in fields
+    result_with_fields = serialize(resource_data, fields=["contact"])
+    assert "contact" in result_with_fields
+    assert result_with_fields["contact"] == {}


### PR DESCRIPTION
## Summary

Fixes a regression in v2.0.6 where `save(update_fields=[...])` fails with `KeyError` when one of the specified fields has an empty list (`[]`) or empty dict (`{}`) value.

**Root cause:** `serialize()` always calls `clean_empty_values()`, which strips empty lists and dicts from the output. When `save()` then tries to extract the specified fields with `data = {key: data[key] for key in fields}`, the missing key raises `KeyError`.

**Fix:** `serialize()` now accepts an optional `fields` parameter. When provided, empty values for those specific keys are preserved after cleaning. This ensures that users can intentionally set fields to `[]` or `{}` to clear them via a partial update, without breaking the serialization pipeline for other fields.

## Changes

| File | Change |
|------|--------|
| `fhirpy/base/resource.py` | Add `fields` parameter to `serialize()`; restore empty values for specified fields after `clean_empty_values()` |
| `fhirpy/base/lib_async.py` | Pass `fields` to `serialize()` in `AsyncClient.save()` |
| `fhirpy/base/lib_sync.py` | Pass `fields` to `serialize()` in `SyncClient.save()` |
| `tests/test_utils.py` | Add regression tests for empty list and empty dict preservation |

## Verification

```
tests/test_utils.py — 12 passed
tests/test_searchset.py — 50 passed
tests/test_lib_base.py — 50 passed
Total: 112 passed, 0 failed
```

## Reproduction (before fix)

```python
resource = client.resource("Patient", generalPractitioner=[practitioner1])
await resource.save()

resource["generalPractitioner"] = []
await resource.save(update_fields=["generalPractitioner"])
# KeyError: 'generalPractitioner' — empty list was stripped by clean_empty_values
```

After fix, the empty list is preserved for the specified field and the save succeeds.

Fixes #146

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
