### PR TITLE
docs: add autohooks setup and mypy CI check (Fixes #144)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,18 @@ on:
   - pull_request
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install mypy
+      - name: Run mypy
+        run: mypy fhirpy/
   build:
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -786,8 +786,15 @@ pip install -r requirements.txt
 
 If you've already installed fhir-py library and want to test the last changes, reinstall it by running `python setup.py install` (or uninstall `pip uninstall fhirpy`)
 
-3. Provide ENV variables `FHIR_SERVER_URL` and `FHIR_SERVER_AUTHORIZATION`, or edit tests/config.py
+3. Set up pre-commit hooks with autohooks:
+```
+pip install autohooks
+autohooks activate
+```
+This runs mypy type checking and ruff linting/formatting automatically before each commit.
 
-4. Run `pytest`
+4. Provide ENV variables `FHIR_SERVER_URL` and `FHIR_SERVER_AUTHORIZATION`, or edit tests/config.py
+
+5. Run `pytest`
 
 If you've found any bugs or think that some part of fhir-py is not compatible with FHIR spec, feel free to create an issue/pull request.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,9 @@ unfixable = ["F401"]
 [tool.autohooks]
 mode = "pipenv"
 pre-commit = ["autohooks.plugins.mypy", "autohooks.plugins.ruff.check", "autohooks.plugins.ruff.format"]
+
+[tool.mypy]
+python_version = "3.9"
+ignore_missing_imports = true
+warn_return_any = true
+warn_unused_configs = true


### PR DESCRIPTION
Fixes #144

## Problem
The development setup instructions in README.md didn't mention `autohooks activate` for setting up pre-commit hooks, and the CI workflow didn't include a mypy type checking step.

## Solution
- Added step 3 to development instructions: `pip install autohooks && autohooks activate` with explanation that it runs mypy and ruff on pre-commit
- Added a `lint` job to the GitHub Actions workflow that runs `mypy fhirpy/` on Python 3.12
- Added `[tool.mypy]` configuration to pyproject.toml with reasonable defaults (`ignore_missing_imports`, `warn_return_any`, `warn_unused_configs`)

## Verification
- README step numbering updated consistently (3→autohooks, 4→ENV vars, 5→pytest)
- build.yaml updated with GitHub Actions v4/v5 (`checkout@v4`, `setup-python@v5`)
- pyproject.toml `[tool.mypy]` section added and syntactically valid

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-07-02 | Added autohooks setup instructions, mypy CI job, and mypy config | rtmalikian |

### Files Changed
- README.md — Added autohooks activation step to development instructions
- .github/workflows/build.yaml — Added standalone `lint` job for mypy type checking
- pyproject.toml — Added `[tool.mypy]` configuration section

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **DeepSeek-v4-pro** (DeepSeek) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
